### PR TITLE
Bump Trivy to v0.54.1 and trivy-adapter to v0.31.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,8 @@ PREPARE_VERSION_NAME=versions
 
 #versions
 REGISTRYVERSION=v2.8.3-patch-redis
-TRIVYVERSION=v0.51.2
-TRIVYADAPTERVERSION=v0.31.2
+TRIVYVERSION=v0.54.1
+TRIVYADAPTERVERSION=v0.31.3
 
 # version of registry for pulling the source code
 REGISTRY_SRC_TAG=v2.8.3


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

Bump Trivy to v0.54.1 and trivy-adapter to v0.31.3

# Issue being fixed
There have been some significant changes in trivy that I'd love to see in harbor 2.11.x

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
